### PR TITLE
Fix Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,21 @@ python:
   - "3.4"
   - "2.7"
   - "2.6"
-  
+
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
+# Build steps taken from
+# https://github.com/nanomsg/nanomsg#build-it-with-cmake
 install:
   - git clone --quiet --depth=100 "https://github.com/nanomsg/nanomsg.git" ~/builds/nanomsg
       && pushd ~/builds/nanomsg
-      && ./autogen.sh
-      && ./configure
-      && make 
-      && sudo make install
-      && popd;
+      && mkdir build
+      && cd build
+      && cmake ..
+      && cmake --build .
+      && ctest -C Debug .
+      && sudo cmake --build . --target install
+      && sudo ldconfig
+      && popd
 
-# command to run tests, e.g. python setup.py test      
+# command to run tests, e.g. python setup.py test
 script: LD_LIBRARY_PATH=/lib:/usr/lib:/usr/local/lib python setup.py test


### PR DESCRIPTION
The Nanomsg repository changed to use cmake as its build tool.  This updates the Travis build script to  use cmake.  Tests pass now.
